### PR TITLE
Add support for Goldair Climate component

### DIFF
--- a/customjson/components/custom_updater.py
+++ b/customjson/components/custom_updater.py
@@ -15,6 +15,10 @@ JSONFILES = [
         "jsonfile": "custom_updater.json",
     },
     {"repository": "StyraHem/hass", "jsonfile": "custom_updater.json"},
+    {
+        "repository": "nikrolls/homeassistant-goldair-climate",
+        "jsonfile": "custom_updater.json"
+    },
 ]
 
 


### PR DESCRIPTION
This component integrates Goldair WiFi heaters (and in the future, dehumidifiers) based on non-cloud Tuya boards.